### PR TITLE
Call buildSync implicitly whenever needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ heaps can be quite large, and this library isn't terribly efficient yet so at ti
 const Heapsnapshot = require('heapsnapshot');
 const snapshot = Heapsnapshot.fromFileSync(__dirname + '/container.heapsnapshot');
 
-// TODO: iterate for building (so we can do it eventually incrementally)
-snapshot.buildSync(); // alternatively build() is a generator, which allows for incremental building.
-
 // get all nodes
 const nodes = [...snapshot];
 const containers = nodes.filter(x => x.type === 'object' && x.name === 'Container');
@@ -33,10 +30,7 @@ or if you can use `for .. of`:
 const Heapsnapshot = require('heapsnapshot');
 const snapshot = Heapsnapshot.fromFileSync(__dirname + '/container.heapsnapshot');
 
-// TODO: iterate for building (so we can do it eventually incrementally)
-snapshot.buildSync(); // alternatively build() is a generator, which allows for incremental building.
-
-// get all nodes
+// loop through all nodes
 for (const node of snapshot) {
   if (node.type === 'object' && node.name === 'Container') {
     const path = Heapsnapshot.pathToRoot(node);

--- a/examples/index.js
+++ b/examples/index.js
@@ -14,31 +14,26 @@ function rank(node, value = 0) {
 console.log('reading');
 const snapshot = Heapsnapshot.fromFileSync(__dirname + '/container.heapsnapshot');
 
-// build
-console.log('building');
-snapshot.buildSync();
-
-console.log('all')
-let all = [...snapshot.nodeIterator()];
+console.log('all');
+let all = [...snapshot];
 // let allEdges = [...snapshot.edgeIterator()];
 
-console.log('searching...')
+console.log('searching...');
 let containers = all.filter(x => x.type === 'object' && x.name === 'Container');
 // let container = all.find(x => x.name === '__container__');
 // let self      = all.find(x => x.name === 'self');
 // let app       = all.find(x => x.name === 'MyBundledApp');
 
 let ignored = [];
-const pathToRoot = require('../lib/path-to-root');
 console.log('testing');
 
-let visited = new WeakSet()
+let visited = new WeakSet();
 let path;
 let count = 0;
-while(path = pathToRoot(containers[0], visited)) {
+while(path = Heapsnapshot.pathToRoot(containers[0], visited)) {
   if (path.length < 2) { continue; }
   count++;
-  visited = new WeakSet()
+  visited = new WeakSet();
   ignored.push(path[1]);
   ignored.forEach(node => visited.add(node))
   console.log(`path ${count}:`, path.join(' -> '));

--- a/lib/heapsnapshot.js
+++ b/lib/heapsnapshot.js
@@ -52,16 +52,15 @@ module.exports = class Heapsnapshot {
     IN_EDGES.set(this, Object.create(null));
 
     this.root = null;
+    this._isBuilt = false;
   }
 
   summary() {
-    const iterator = this.nodeIterator();
     let summary = Object.create(null);
-    for (let node of iterator) {
+    for (let node of this) {
       summary[node.type] = summary[node.type] || 0;
       summary[node.type]++;
     }
-
     return summary;
   }
 
@@ -69,11 +68,14 @@ module.exports = class Heapsnapshot {
     return new this(JSON.parse(fs.readFileSync(filePath, 'UTF8')));
   }
 
-  buildSync() {
-    for (let _ of this.build()) { }
+  _buildSync() {
+    if (!this._isBuilt) {
+      for (let _ of this._build()) { }
+      this._isBuilt = true;
+    }
   }
 
-  * build() {
+  * _build() {
     let index = 0;
     let edge = 0;
     let parsed = PARSED.get(this);
@@ -110,6 +112,7 @@ module.exports = class Heapsnapshot {
   }
 
   * nodeIterator() {
+    this._buildSync();
     let index = 0;
     let parsed = PARSED.get(this);
 
@@ -124,6 +127,7 @@ module.exports = class Heapsnapshot {
   }
 
   * edgeIterator() {
+    this._buildSync();
     let index = 0;
     let parsed = PARSED.get(this);
 
@@ -186,7 +190,7 @@ module.exports = class Heapsnapshot {
   nodeForIndex(index) {
     let node = NODES.get(this)[index];
     if (node === undefined) {
-      throw new Error(`unknonw node for index: ${index}`)
+      throw new Error(`unknown node for index: ${index}`);
     }
 
     return node;
@@ -196,7 +200,7 @@ module.exports = class Heapsnapshot {
     let edge = EDGES.get(this)[index];
 
     if (edge === undefined) {
-      throw new Error(`unknonw edge for index: ${index}`)
+      throw new Error(`unknown edge for index: ${index}`);
     }
 
     return edge;

--- a/lib/path-to-root.js
+++ b/lib/path-to-root.js
@@ -2,8 +2,9 @@
 
 const Node = require('./node');
 const ROOT = new Node(null, 0, 'root');
-module.exports = function pathToRoot(node, visited, fromEdge) {
-  visited =  visited || new WeakSet();
+module.exports = function pathToRoot(node) {
+  let visited =  arguments[1] || new WeakSet();
+  let fromEdge = arguments[2];
 
   let path = _pathToRoot(node, visited, fromEdge);
   if (path.length > 0 && path[path.length - 1].index !== 0) {

--- a/lib/path-to-root.js
+++ b/lib/path-to-root.js
@@ -2,10 +2,7 @@
 
 const Node = require('./node');
 const ROOT = new Node(null, 0, 'root');
-module.exports = function pathToRoot(node) {
-  let visited =  arguments[1] || new WeakSet();
-  let fromEdge = arguments[2];
-
+module.exports = function pathToRoot(node, visited = new WeakSet(), fromEdge) {
   let path = _pathToRoot(node, visited, fromEdge);
   if (path.length > 0 && path[path.length - 1].index !== 0) {
     throw Error(`${node} has no path to root`);

--- a/lib/path-to-root.js
+++ b/lib/path-to-root.js
@@ -2,7 +2,9 @@
 
 const Node = require('./node');
 const ROOT = new Node(null, 0, 'root');
-module.exports = function pathToRoot(node, visited = new WeakSet(), fromEdge) {
+module.exports = function pathToRoot(node, visited, fromEdge) {
+  visited =  visited || new WeakSet();
+
   let path = _pathToRoot(node, visited, fromEdge);
   if (path.length > 0 && path[path.length - 1].index !== 0) {
     throw Error(`${node} has no path to root`);

--- a/tests/heapsnapshot-test.js
+++ b/tests/heapsnapshot-test.js
@@ -12,7 +12,6 @@ describe('Heapsnapshot', function() {
 
   before(function() {
     small = Heapsnapshot.fromFileSync(EXAMPLE_PATH  + "/small.heapsnapshot")
-    small.buildSync();
   });
 
   describe('fromFileSync', function() {


### PR DESCRIPTION
This will reduce the surface of the public api and makes it easier to use the tool.